### PR TITLE
Fix for Pixel 6 speakerphone

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -386,7 +386,7 @@
 				DEVELOPMENT_TEAM = LNLXP4VK97;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -523,7 +523,7 @@
 				DEVELOPMENT_TEAM = LNLXP4VK97;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -551,7 +551,7 @@
 				DEVELOPMENT_TEAM = LNLXP4VK97;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/lib/services/agora/agora_communication_provider.dart
+++ b/lib/services/agora/agora_communication_provider.dart
@@ -247,7 +247,6 @@ class AgoraCommunicationProvider extends CommunicationProvider {
   Future<void> _handleJoinSession(channel, uid, elapsed) async {
     commUid = uid;
     // Update the session to add user information to session display
-    await _engine!.setEnableSpeakerphone(true);
     await sessionProvider.joinSession(
         session: _session!,
         uid: userId,
@@ -255,6 +254,11 @@ class AgoraCommunicationProvider extends CommunicationProvider {
         sessionImage: _sessionImage);
     sessionProvider.activeSession
         ?.userJoined(sessionUserId: commUid.toString());
+    bool? onSpeaker = await _engine!.isSpeakerphoneEnabled();
+    if (onSpeaker != true) {
+      await _engine!.setEnableSpeakerphone(true);
+    }
+
     // notify any callbacks that the user has joined the session
     if (_handler != null && _handler!.joinedCircle != null) {
       _handler!.joinedCircle!(_session!.id, uid.toString());

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: agora_rtc_engine
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.7"
+    version: "4.2.0-rc.2"
   archive:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,7 +48,7 @@ dependencies:
   keyboard_actions: ^3.4.4
   modal_bottom_sheet: ^2.0.0
   cached_network_image: ^3.1.0
-  agora_rtc_engine: ^4.0.7
+  agora_rtc_engine: ^4.2.0-rc.2
   after_layout: ^1.1.0
   permission_handler: ^8.3.0
   image_picker: ^0.8.4+4


### PR DESCRIPTION
- Upgrade to the latest (ore-release) Agora SDK which is the main fix
- Moved speakerphone check/enable to after the `joinSession()` as recommended in docs
- Reduced iOS min target to be a bit more liberal for testing with an older device