### PR TITLE
Add Android CI Releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,26 +7,42 @@ on:
       - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 
 jobs:
-  build_ios:
-   runs-on: macos-11
-   steps:
-    - uses: actions/checkout@v2
-    # Install flutter
-    - uses: subosito/flutter-action@v2
-      with:
-        flutter-version: '2.8.x'
-        cache: true
-    - uses: webfactory/ssh-agent@v0.5.4
-      with:
-        ssh-private-key: ${{ secrets.MATCH_REPO_PRIVATE_KEY }}
-    - run: fastlane ios build
-      env:
-        MATCH_PASSWORD: ${{ secrets.FASTLANE_MATCH_PASSWORD }}
-    - name: Release
-      uses: softprops/action-gh-release@v1
-      with:
-        files: totem.ipa
-        body: Internal release
-    - run: fastlane ios internal
-      env:
-        APPLE_STORE_CONNECT_API_KEY: ${{ secrets.APPLE_STORE_CONNECT_API_KEY }}
+  # build_ios:
+  #  runs-on: macos-11
+  #  steps:
+  #   - uses: actions/checkout@v2
+  #   # Install flutter
+  #   - uses: subosito/flutter-action@v2
+  #     with:
+  #       flutter-version: '2.8.x'
+  #       cache: true
+  #   - uses: webfactory/ssh-agent@v0.5.4
+  #     with:
+  #       ssh-private-key: ${{ secrets.MATCH_REPO_PRIVATE_KEY }}
+  #   - run: fastlane ios build
+  #     env:
+  #       MATCH_PASSWORD: ${{ secrets.FASTLANE_MATCH_PASSWORD }}
+  #   - name: Release
+  #     uses: softprops/action-gh-release@v1
+  #     with:
+  #       files: totem.ipa
+  #       body: Internal release
+  #   - run: fastlane ios internal
+  #     env:
+  #       APPLE_STORE_CONNECT_API_KEY: ${{ secrets.APPLE_STORE_CONNECT_API_KEY }}
+  build_android:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '2.8.x'
+          cache: true
+      - name: Setup secrets
+        run: |
+          echo "$PLAY_KEYSTORE_B64" | base64 --decode > android/keystore.jks
+          echo "$PLAY_KEYSTORE_PROPERTIES" > android/key.properties
+        env:
+          PLAY_KEYSTORE_B64: ${{ secrets.PLAY_KEYSTORE_B64 }}
+          PLAY_KEYSTORE_PROPERTIES: ${{ secrets.PLAY_KEYSTORE_PROPERTIES }}
+      - run: flutter build appbundle

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,34 +7,35 @@ on:
       - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 
 jobs:
-  # build_ios:
-  #  runs-on: macos-11
-  #  steps:
-  #   - uses: actions/checkout@v2
-  #   # Install flutter
-  #   - uses: subosito/flutter-action@v2
-  #     with:
-  #       flutter-version: '2.8.x'
-  #       cache: true
-  #   - uses: webfactory/ssh-agent@v0.5.4
-  #     with:
-  #       ssh-private-key: ${{ secrets.MATCH_REPO_PRIVATE_KEY }}
-  #   - run: fastlane ios build
-  #     env:
-  #       MATCH_PASSWORD: ${{ secrets.FASTLANE_MATCH_PASSWORD }}
-  #   - name: Release
-  #     uses: softprops/action-gh-release@v1
-  #     with:
-  #       files: totem.ipa
-  #       body: Internal release
-  #   - run: fastlane ios internal
-  #     env:
-  #       APPLE_STORE_CONNECT_API_KEY: ${{ secrets.APPLE_STORE_CONNECT_API_KEY }}
+  build_ios:
+   runs-on: macos-11
+   steps:
+    - uses: actions/checkout@v2
+    - name: Install Flutter
+      uses: subosito/flutter-action@v2
+      with:
+        flutter-version: '2.8.x'
+        cache: true
+    - uses: webfactory/ssh-agent@v0.5.4
+      with:
+        ssh-private-key: ${{ secrets.MATCH_REPO_PRIVATE_KEY }}
+    - run: fastlane ios build
+      env:
+        MATCH_PASSWORD: ${{ secrets.FASTLANE_MATCH_PASSWORD }}
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      with:
+        files: totem.ipa
+        body: iOS release
+    - run: fastlane ios internal
+      env:
+        APPLE_STORE_CONNECT_API_KEY: ${{ secrets.APPLE_STORE_CONNECT_API_KEY }}
   build_android:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: subosito/flutter-action@v2
+      - name: Install Flutter
+        uses: subosito/flutter-action@v2
         with:
           flutter-version: '2.8.x'
           cache: true
@@ -46,3 +47,9 @@ jobs:
           PLAY_KEYSTORE_B64: ${{ secrets.PLAY_KEYSTORE_B64 }}
           PLAY_KEYSTORE_PROPERTIES: ${{ secrets.PLAY_KEYSTORE_PROPERTIES }}
       - run: flutter build appbundle
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: build/app/outputs/bundle/release/app-release.aab
+          body: Android release
+      - run: fastlane android internal

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ app.*.map.json
 totem.ipa
 totem.app.dSYM.zip
 report.xml
+play-deploy-key.json

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ build: build-android build-ios
 build-android:
 	flutter build appbundle
 
+publish-andorid:
+	fastlane android internal
+
 build-ios:
 	fastlane ios build
 

--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,8 +1,9 @@
+# iOS
 app_identifier("io.kbl.totem") # The bundle identifier of your app
 apple_id("lopkerk@gmail.com") # Your Apple email address
 
 itc_team_id("119963401") # App Store Connect Team ID
 team_id("LNLXP4VK97") # Developer Portal Team ID
 
-# For more information about the Appfile, see:
-#     https://docs.fastlane.tools/advanced/#appfile
+# Android
+package_name("io.kbl.totem") # e.g. com.krausefx.app

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -49,7 +49,7 @@ end
 
 # Android lanes
 platform :android do
-  desc "Submit a new Beta Build to Crashlytics Beta"
+  desc "Submit a new Build to the Google Play internal test track"
   lane :internal do
     puts "hi"
     if is_ci
@@ -57,6 +57,6 @@ platform :android do
     else
       key_data = IO.read("../play-deploy-key.json")
     end
-    upload_to_play_store(track: 'internal', json_key_data: key_data, aab: "build/app/outputs/bundle/release/app-release.aab")
+    # upload_to_play_store(track: 'internal', json_key_data: key_data, aab: "build/app/outputs/bundle/release/app-release.aab")
   end
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,15 +1,5 @@
 # This file contains the fastlane.tools configuration
 # You can find the documentation at https://docs.fastlane.tools
-#
-# For a list of all available actions, check out
-#
-#     https://docs.fastlane.tools/actions
-#
-# For a list of all available plugins, check out
-#
-#     https://docs.fastlane.tools/plugins/available-plugins
-#
-require 'json'
 opt_out_usage
 
 # iOS lanes
@@ -42,7 +32,7 @@ platform :ios do
         key_content: ENV["APPLE_STORE_CONNECT_API_KEY"]
       )
     end
-    # upload_to_testflight
+    upload_to_testflight
   end
 end
 
@@ -57,6 +47,6 @@ platform :android do
     else
       key_data = IO.read("../play-deploy-key.json")
     end
-    # upload_to_play_store(track: 'internal', json_key_data: key_data, aab: "build/app/outputs/bundle/release/app-release.aab")
+    upload_to_play_store(track: 'internal', json_key_data: key_data, aab: "build/app/outputs/bundle/release/app-release.aab")
   end
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -9,11 +9,10 @@
 #
 #     https://docs.fastlane.tools/plugins/available-plugins
 #
-
-# Uncomment the line if you want fastlane to automatically update itself
-# update_fastlane
+require 'json'
 opt_out_usage
 
+# iOS lanes
 platform :ios do
   desc "Create signed release build"
   lane :build do
@@ -44,5 +43,20 @@ platform :ios do
       )
     end
     # upload_to_testflight
+  end
+end
+
+
+# Android lanes
+platform :android do
+  desc "Submit a new Beta Build to Crashlytics Beta"
+  lane :internal do
+    puts "hi"
+    if is_ci
+      key_data = ENV["PLAY_DEPLOY_KEY"]
+    else
+      key_data = IO.read("../play-deploy-key.json")
+    end
+    upload_to_play_store(track: 'internal', json_key_data: key_data, aab: "build/app/outputs/bundle/release/app-release.aab")
   end
 end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -15,13 +15,42 @@ For _fastlane_ installation instructions, see [Installing _fastlane_](https://do
 
 ## iOS
 
+### ios build
+
+```sh
+[bundle exec] fastlane ios build
+```
+
+Create signed release build
+
 ### ios internal
 
 ```sh
 [bundle exec] fastlane ios internal
 ```
 
-Push a new test build to TestFlight
+Push to internal TestFlight users
+
+----
+
+
+## Android
+
+### android build
+
+```sh
+[bundle exec] fastlane android build
+```
+
+Submit a new Beta Build to Crashlytics Beta
+
+### android internal
+
+```sh
+[bundle exec] fastlane android internal
+```
+
+
 
 ----
 


### PR DESCRIPTION
This adds the Android CI part. Similar to iOS, this will release a new version of the Android app to the internal Play users. We'll need to use the UI to promote builds to beta users for now.