### PR TITLE
Only show muted icon

### DIFF
--- a/lib/app/circle/components/circle_session_participant.dart
+++ b/lib/app/circle/components/circle_session_participant.dart
@@ -30,32 +30,33 @@ class CircleSessionParticipant extends ConsumerWidget {
           PositionedDirectional(
             top: 5,
             end: 5,
-            child: _muteButton(context, participant),
+            child: _muteIndicator(context, participant),
           ),
         ],
       ),
     );
   }
 
-  Widget _muteButton(BuildContext context, SessionParticipant participant) {
+  Widget _muteIndicator(BuildContext context, SessionParticipant participant) {
     final themeColors = Theme.of(context).themeColors;
     final bool muted = participant.muted;
-    return Container(
-      width: 32,
-      height: 32,
-      decoration: ShapeDecoration(
-        color: muted ? themeColors.primaryText : themeColors.primary,
-        shape: const CircleBorder(),
-      ),
-      child: Center(
-        child: SvgPicture.asset(
-          participant.muted
-              ? 'assets/microphone_mute.svg'
-              : 'assets/microphone.svg',
-          color: muted ? themeColors.primary : themeColors.primaryText,
-          fit: BoxFit.contain,
+    if (muted) {
+      return Container(
+        width: 32,
+        height: 32,
+        decoration: ShapeDecoration(
+          color: muted ? themeColors.primaryText : themeColors.primary,
+          shape: const CircleBorder(),
         ),
-      ),
-    );
+        child: Center(
+          child: SvgPicture.asset(
+            'assets/microphone_mute.svg',
+            color: themeColors.primary,
+            fit: BoxFit.contain,
+          ),
+        ),
+      );
+    }
+    return Container();
   }
 }

--- a/lib/services/agora/agora_communication_provider.dart
+++ b/lib/services/agora/agora_communication_provider.dart
@@ -167,6 +167,7 @@ class AgoraCommunicationProvider extends CommunicationProvider {
               userInfoUpdated: _handleUserInfoUpdated,
               userJoined: _handleUserJoined,
               userOffline: _handleUserOffline,
+              audioVolumeIndication: _handleAudioVolumeIndication,
             ),
           );
         } else {
@@ -363,5 +364,10 @@ class AgoraCommunicationProvider extends CommunicationProvider {
       }
       _lastState = session.state;
     }
+  }
+
+  void _handleAudioVolumeIndication(
+      List<AudioVolumeInfo> speakers, int totalVolume) {
+    // TODO - handle volume indication
   }
 }


### PR DESCRIPTION
This PR changes the pre-circle screen to only show the muted icon when the person is muted and not when they are unmuted.

This also creates a stub handler for audio indication. Open question: what's the best way to get a stream of this data in a widget?

The data looks like: `{uid: 0, volume: 7, vad: 1, channelId: }` where `vad` is 1 or 0 indicating if the person is talking.