### PR TITLE
Recover from audio input error

### DIFF
--- a/lib/services/agora/agora_communication_provider.dart
+++ b/lib/services/agora/agora_communication_provider.dart
@@ -385,9 +385,16 @@ class AgoraCommunicationProvider extends CommunicationProvider {
   }
 
   void _handleLocalAudioStateChanged(
-      AudioLocalState state, AudioLocalError error) {
+      AudioLocalState state, AudioLocalError error) async {
     // handles local changes to audio
     debugPrint('local audio state changes: ' + state.toString());
+    if (error != AudioLocalError.Ok) {
+      debugPrint('local audio state error: ${error.toString()}');
+      if (error == AudioLocalError.RecordFailure) {
+        await _engine!.enableLocalAudio(false);
+        await _engine!.enableLocalAudio(true);
+      }
+    }
   }
 
   void _handleRemoteAudioStateChanged(int uid, AudioRemoteState state,

--- a/lib/services/agora/agora_communication_provider.dart
+++ b/lib/services/agora/agora_communication_provider.dart
@@ -394,10 +394,15 @@ class AgoraCommunicationProvider extends CommunicationProvider {
         if (muted) {
           await _engine!.muteLocalAudioStream(false);
         }
-        await _engine!.enableLocalAudio(false);
-        await _engine!.enableLocalAudio(true);
-        if (muted) {
-          await _engine!.muteLocalAudioStream(true);
+        try {
+          await _engine!.enableLocalAudio(false);
+          await _engine!.enableLocalAudio(true);
+        } catch (ex) {
+          debugPrint('Failed resetting local audio ' + ex.toString());
+        } finally {
+          if (muted) {
+            await _engine!.muteLocalAudioStream(true);
+          }
         }
       }
     }

--- a/lib/services/agora/agora_communication_provider.dart
+++ b/lib/services/agora/agora_communication_provider.dart
@@ -391,8 +391,14 @@ class AgoraCommunicationProvider extends CommunicationProvider {
     if (error != AudioLocalError.Ok) {
       debugPrint('local audio state error: ${error.toString()}');
       if (error == AudioLocalError.RecordFailure) {
+        if (muted) {
+          await _engine!.muteLocalAudioStream(false);
+        }
         await _engine!.enableLocalAudio(false);
         await _engine!.enableLocalAudio(true);
+        if (muted) {
+          await _engine!.muteLocalAudioStream(true);
+        }
       }
     }
   }


### PR DESCRIPTION
When the audio state indicates an error, check if it is a `RecordFailure` and if it is then disable and re-enable local audio to reset the input device.