### PR TITLE
Add a SECRET dev page

### DIFF
--- a/lib/app_routes.dart
+++ b/lib/app_routes.dart
@@ -73,7 +73,7 @@ class AppRoutes {
         break;
       case dev:
         return MaterialPageRoute(
-          builder: (_) => DevPage(),
+          builder: (_) => const DevPage(),
           settings: settings,
         );
       default:

--- a/lib/app_routes.dart
+++ b/lib/app_routes.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'app/index.dart';
 import 'components/index.dart';
 import 'models/index.dart';
+import 'dev/dev_page.dart';
 
 class AppRoutes {
   static const String loginPhone = '/login/phone';
@@ -13,6 +14,7 @@ class AppRoutes {
   static const String appSettings = '/settings';
   static const String userProfile = '/profile';
   static const String circle = '/circle';
+  static const String dev = '/dev';
 
   static Route<dynamic>? generateRoute(RouteSettings settings) {
     switch (settings.name) {
@@ -69,6 +71,11 @@ class AppRoutes {
               settings: settings);
         }
         break;
+      case dev:
+        return MaterialPageRoute(
+          builder: (_) => DevPage(),
+          settings: settings,
+        );
       default:
         return null;
     }

--- a/lib/dev/dev_page.dart
+++ b/lib/dev/dev_page.dart
@@ -75,7 +75,7 @@ class WidgetContainer extends StatelessWidget {
           right: 0,
           top: 0,
           child: IconButton(
-            icon: Icon(Icons.close),
+            icon: const Icon(Icons.close),
             onPressed: () {
               reset();
             },

--- a/lib/dev/dev_page.dart
+++ b/lib/dev/dev_page.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:totem/theme/index.dart';
+
+import '../components/widgets/content_divider.dart';
+import 'layouts.dart';
+
+final widgetList = <String, Function>{"CircleLayout": CircleLayout.new};
+
+class DevPage extends StatefulWidget {
+  const DevPage({Key? key}) : super(key: key);
+
+  @override
+  State<DevPage> createState() => _DevPageState();
+}
+
+class _DevPageState extends State<DevPage> {
+  String? displayWidget;
+  final stateKey = "dev/currentwidget";
+  @override
+  Widget build(BuildContext context) {
+    final themeColors = Theme.of(context).themeColors;
+    Widget widget = WidgetList(changeWidget);
+    if (displayWidget != null) {
+      widget =
+          WidgetContainer(child: widgetList[displayWidget!]!(), reset: reset);
+    }
+    return Scaffold(
+        backgroundColor: themeColors.dialogBackground, body: widget);
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _init();
+  }
+
+  _init() async {
+    final prefs = await SharedPreferences.getInstance();
+    if (prefs.containsKey(stateKey)) {
+      setState(() {
+        displayWidget = prefs.getString(stateKey);
+      });
+    }
+  }
+
+  changeWidget(String widget) async {
+    final prefs = await SharedPreferences.getInstance();
+    prefs.setString(stateKey, widget);
+    setState(() {
+      displayWidget = widget;
+    });
+  }
+
+  reset() async {
+    final prefs = await SharedPreferences.getInstance();
+    prefs.remove(stateKey);
+    setState(() {
+      displayWidget = null;
+    });
+  }
+}
+
+class WidgetContainer extends StatelessWidget {
+  const WidgetContainer({Key? key, required this.child, required this.reset})
+      : super(key: key);
+  final Function reset;
+  final Widget child;
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        child,
+        Positioned(
+          right: 0,
+          top: 0,
+          child: IconButton(
+            icon: Icon(Icons.close),
+            onPressed: () {
+              reset();
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class WidgetList extends StatelessWidget {
+  const WidgetList(this.changeWidget, {Key? key}) : super(key: key);
+  final Function(String) changeWidget;
+  @override
+  Widget build(BuildContext context) {
+    final textStyles = Theme.of(context).textStyles;
+    var children = widgetList.keys.map((key) {
+      return ListTile(
+        title: Text(key),
+        onTap: () {
+          changeWidget(key);
+        },
+      );
+    }).toList();
+    return Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(children: [
+          Text("Dev Page!", style: textStyles.headline1),
+          const Center(
+            child: ContentDivider(),
+          ),
+          const Padding(padding: EdgeInsets.only(top: 20)),
+          Column(
+            children: children,
+          )
+        ]));
+  }
+}

--- a/lib/dev/layouts.dart
+++ b/lib/dev/layouts.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+
+class CircleLayout extends StatelessWidget {
+  const CircleLayout({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        if (constraints.maxWidth > 600) {
+          return _buildWideContainers();
+        } else {
+          return _buildNormalContainer();
+        }
+      },
+    );
+  }
+
+  Widget _buildNormalContainer() {
+    return Center(
+      child: Container(
+        height: 100.0,
+        width: 100.0,
+        color: Colors.red,
+      ),
+    );
+  }
+
+  Widget _buildWideContainers() {
+    return Center(
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+        children: <Widget>[
+          Container(
+            height: 200.0,
+            width: 100.0,
+            color: Colors.red,
+          ),
+          Container(
+            height: 100.0,
+            width: 100.0,
+            color: Colors.yellow,
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Add a dev page at `/dev`. The page allows us to add arbitrary widgets to a list for testing and quick, non-logged in iterations. Everything will be faked here with a focus on development speed.

Do add a new widget, add the name as a string and the constructor in the `widgetList` variable in the `dev_page.dart` file. This will add an entry for it in the dev list.

This also includes a rudimentary navigation system that can survive hot reloads, using shared_preferences. An `x` will be rendered on all widget screens to go back to the widget list.