### PR TITLE
support for reordering live session

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -292,7 +292,7 @@ SPEC CHECKSUMS:
   FirebaseCoreDiagnostics: 92e07a649aeb66352b319d43bdd2ee3942af84cb
   FirebaseCrashlytics: feb07e4e9187be3c23c6a846cce4824e5ce2dd0b
   FirebaseDynamicLinks: 1dc816ef789c5adac6fede0b46d11478175c70e4
-  FirebaseFirestore: 3a0a7e1e72e4359b92d4c38de06d84e4c4900c0a
+  FirebaseFirestore: cb361b7f8f225a225c9f11b8d42066baebb1630c
   FirebaseFunctions: f9346c6afd2c7d84aabb331d70dd0c8309e1abe1
   FirebaseInstallations: 40bd9054049b2eae9a2c38ef1c3dd213df3605cd
   FirebaseStorage: 8019af461599b2c3bc61c6a5dbdfa3d2de66a4d9

--- a/lib/app/circle/circle_session_info_page.dart
+++ b/lib/app/circle/circle_session_info_page.dart
@@ -35,10 +35,11 @@ class CircleSessionInfoPageState extends ConsumerState<CircleSessionInfoPage> {
   SessionParticipant? me;
   late List<SessionParticipant> _participants;
   late ActiveSession _activeSession;
-
+  late SessionState _sessionState;
   @override
   void initState() {
     _activeSession = ref.read(activeSessionProvider);
+    _sessionState = _activeSession.state;
     _participants =
         List<SessionParticipant>.from(_activeSession.speakOrderParticipants);
     me = _activeSession.me();
@@ -214,6 +215,12 @@ class CircleSessionInfoPageState extends ConsumerState<CircleSessionInfoPage> {
           shrinkWrap: true,
           itemBuilder: (context, index) {
             SessionParticipant participant = participants[index];
+            if (_sessionState == SessionState.live && index == 0) {
+              // for a live session, the first user in the list is the current
+              // totem user. Don't allow them to be reordered for this case
+              return CircleSessionParticipantListItem(
+                  horizontalPadding: 0, participant: participants[index]);
+            }
             return ReorderableItem(
               key: ValueKey(participant.sessionUserId!),
               childBuilder: (BuildContext context, ReorderableItemState state) {

--- a/lib/app/circle/components/circle_session_controls.dart
+++ b/lib/app/circle/components/circle_session_controls.dart
@@ -20,7 +20,7 @@ class CircleSessionControls extends ConsumerStatefulWidget {
 class CircleSessionControlsState extends ConsumerState<CircleSessionControls> {
   bool _more = false;
   Timer? _timer;
-  static const double _btnSpacing = 8;
+  static const double _btnSpacing = 6;
 
   @override
   void dispose() {
@@ -257,6 +257,16 @@ class CircleSessionControlsState extends ConsumerState<CircleSessionControls> {
                 svgImage: 'assets/leave.svg',
                 onPressed: () {
                   _endSessionPrompt(context, ref, role);
+                },
+              ),
+              const SizedBox(width: _btnSpacing),
+              ThemedControlButton(
+                label: t.info,
+                labelColor: themeColors.reversedText,
+                svgImage: 'assets/info.svg',
+                onPressed: () {
+                  debugPrint('info pressed');
+                  _showCircleInfo(context);
                 },
               ),
               Expanded(


### PR DESCRIPTION
#178 - included the 'info' button for the keeper secondary buttons list. Can order the people that aren't the current keeper