### PR TITLE
Add more lints to help with missing async

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,1 +1,8 @@
 include: package:flutter_lints/flutter.yaml
+
+linter:
+  rules:
+    - always_declare_return_types
+    # - prefer_single_quotes
+    - unawaited_futures
+    - unsafe_html

--- a/lib/app/auth.dart
+++ b/lib/app/auth.dart
@@ -105,7 +105,7 @@ class _AuthWidget extends ConsumerState<AuthWidget> {
                   if (newCircle != null) {
                     _joinCircle(newCircle, repo);
                   } else {
-                    _promptMissingCircle();
+                    await _promptMissingCircle();
                   }
                 } else {
                   // join the pending one
@@ -114,7 +114,7 @@ class _AuthWidget extends ConsumerState<AuthWidget> {
               }
             } else {
               // circle doesn't exist... give an uh-oh message!
-              _promptMissingCircle();
+              await _promptMissingCircle();
             }
           } else {
             // cache as a pending link
@@ -130,7 +130,7 @@ class _AuthWidget extends ConsumerState<AuthWidget> {
       circle: circle,
     );
     if (!mounted) return;
-    Navigator.of(context).pushNamed(AppRoutes.circle, arguments: {
+    await Navigator.of(context).pushNamed(AppRoutes.circle, arguments: {
       'session': circle.snapSession,
     });
   }

--- a/lib/app/circle/circle_create_snap_page.dart
+++ b/lib/app/circle/circle_create_snap_page.dart
@@ -149,7 +149,7 @@ class CircleCreateSnapPageState extends ConsumerState<CircleCreateSnapPage> {
           circle: circle,
         );
         if (!mounted) return;
-        Navigator.pushReplacementNamed(context, AppRoutes.circle, arguments: {
+        await Navigator.pushReplacementNamed(context, AppRoutes.circle, arguments: {
           'session': circle.snapSession,
         });
       } /*else {
@@ -160,7 +160,7 @@ class CircleCreateSnapPageState extends ConsumerState<CircleCreateSnapPage> {
       } */
     } on ServiceException catch (ex) {
       debugPrint('Error creating circle: $ex');
-      _showCreateError(ex);
+      await _showCreateError(ex);
     }
     setState(() => _busy = false);
   }

--- a/lib/app/circle/circle_page.dart
+++ b/lib/app/circle/circle_page.dart
@@ -187,7 +187,7 @@ class CirclePageState extends ConsumerState<CirclePage> {
     final repo = ref.read(repositoryProvider);
     await repo.activateSession(session: session);
     if (!mounted) return;
-    Navigator.pushReplacement(
+    await Navigator.pushReplacement(
       context,
       FadeRoute(
         page: CircleSessionPage(session: session),

--- a/lib/app/circle/circle_session_info_page.dart
+++ b/lib/app/circle/circle_session_info_page.dart
@@ -224,7 +224,7 @@ class CircleSessionInfoPageState extends ConsumerState<CircleSessionInfoPage> {
         // sorted, save
         // update the list of users
         final repo = ref.read(repositoryProvider);
-        repo.updateActiveSession(repo.activeSession!.reorderParticipants(
+        await repo.updateActiveSession(repo.activeSession!.reorderParticipants(
             _participants
                 .map((element) => element.sessionUserId!)
                 .toList(growable: false)));

--- a/lib/app/circle/components/circle_live_video_session.dart
+++ b/lib/app/circle/components/circle_live_video_session.dart
@@ -392,9 +392,9 @@ class _CircleLiveVideoSessionState
     if (_myTurn) {
       final activeSession = ref.read(activeSessionProvider);
       if (activeSession.totemReceived) {
-        _endTurn(context, activeSession.totemParticipant!);
+        await _endTurn(context, activeSession.totemParticipant!);
       } else {
-        _receiveTurn(context, activeSession.totemParticipant!);
+        await _receiveTurn(context, activeSession.totemParticipant!);
       }
     }
   }

--- a/lib/app/home/components/snap_circles_list.dart
+++ b/lib/app/home/components/snap_circles_list.dart
@@ -103,7 +103,7 @@ class SnapCirclesListState extends ConsumerState<SnapCirclesList> {
       circle: circle,
     );
     if (!mounted) return;
-    Navigator.of(context).pushNamed(AppRoutes.circle, arguments: {
+    await Navigator.of(context).pushNamed(AppRoutes.circle, arguments: {
       'session': circle.snapSession,
     });
 /*REMOVE    var repo = ref.read(repositoryProvider);

--- a/lib/app/home/components/snap_circles_rejoinable.dart
+++ b/lib/app/home/components/snap_circles_rejoinable.dart
@@ -80,7 +80,7 @@ class SnapCirclesRejoinableState extends ConsumerState<SnapCirclesRejoinable> {
       circle: circle,
     );
     if (!mounted) return;
-    Navigator.of(context).pushNamed(AppRoutes.circle, arguments: {
+    await Navigator.of(context).pushNamed(AppRoutes.circle, arguments: {
       'session': circle.snapSession,
     });
   }

--- a/lib/app/login/components/phone_register_code_entry.dart
+++ b/lib/app/login/components/phone_register_code_entry.dart
@@ -39,7 +39,7 @@ class PhoneRegisterCodeEntryState
       final authSvc = ref.read(authServiceProvider);
       final AuthUser? authUser = authSvc.currentUser();
       if (authUser != null && authUser.isNewUser) {
-        Navigator.pushReplacementNamed(
+        await Navigator.pushReplacementNamed(
           context,
           AppRoutes.loginOnboarding,
         );

--- a/lib/app/login/components/phone_register_number_entry.dart
+++ b/lib/app/login/components/phone_register_number_entry.dart
@@ -158,7 +158,7 @@ class PhoneRegisterNumberEntryState
       // chooses a different one than the default
       String isoCode = numberController.isoCode!;
       SharedPreferences prefs = await SharedPreferences.getInstance();
-      prefs.setString('lastIso', isoCode);
+      await prefs.setString('lastIso', isoCode);
 
       debugPrint(number);
       try {

--- a/lib/app/profile/onboarding_profile_page.dart
+++ b/lib/app/profile/onboarding_profile_page.dart
@@ -57,7 +57,7 @@ class OnboardingProfilePageState extends ConsumerState<OnboardingProfilePage> {
       Navigator.of(context).pop();
     } else {
       setState(() => _busy = false);
-      _showUploadError(context, error);
+      await _showUploadError(context, error);
     }
   }
 
@@ -197,7 +197,7 @@ class OnboardingProfilePageState extends ConsumerState<OnboardingProfilePage> {
       _userProfile!.email = _emailController.text;
       if (_pendingImageChange != null) {
         AuthUser user = ref.read(authServiceProvider).currentUser()!;
-        _uploader.currentState!.profileImageUpload(_pendingImageChange!, user);
+        await _uploader.currentState!.profileImageUpload(_pendingImageChange!, user);
         return;
       } else {
         // just save the profile
@@ -441,7 +441,7 @@ class OnboardingProfilePageState extends ConsumerState<OnboardingProfilePage> {
       },
     );
     if (result == 2) {
-      _saveForm();
+      await _saveForm();
       return false;
     }
     return result == 1;

--- a/lib/app/profile/user_profile_page.dart
+++ b/lib/app/profile/user_profile_page.dart
@@ -55,7 +55,7 @@ class UserProfilePageState extends ConsumerState<UserProfilePage> {
 
   @override
   void dispose() async {
-    _pendingImageChangeFile?.delete();
+    await _pendingImageChangeFile?.delete();
     super.dispose();
   }
 
@@ -105,7 +105,7 @@ class UserProfilePageState extends ConsumerState<UserProfilePage> {
                                     ? () async {
                                         await _saveForm();
                                         if (!mounted) return;
-                                        Navigator.maybePop(context);
+                                        await Navigator.maybePop(context);
                                       }
                                     : null,
                                 child: Text(t.save)),
@@ -294,7 +294,7 @@ class UserProfilePageState extends ConsumerState<UserProfilePage> {
     XFile? imagePath = await ProfileImageDialog.showDialog(context,
         userProfile: _userProfile!);
     if (imagePath != null) {
-      _pendingImageChangeFile?.delete();
+      await _pendingImageChangeFile?.delete();
       setState(() {
         _pendingImageChange = imagePath;
         _hasChanged = true;
@@ -309,7 +309,7 @@ class UserProfilePageState extends ConsumerState<UserProfilePage> {
     if (uploadedUrl != null) {
       _userProfile!.image = uploadedUrl;
       // delete pending image
-      _pendingImageChangeFile?.delete();
+      await _pendingImageChangeFile?.delete();
       _pendingImageChangeFile = null;
       _pendingImageChange = null;
       await ref.read(repositoryProvider).updateUserProfile(_userProfile!);
@@ -317,7 +317,7 @@ class UserProfilePageState extends ConsumerState<UserProfilePage> {
     } else {
       // this is an error condition
       setState(() => _busy = false);
-      _showUploadError(context, error);
+      await _showUploadError(context, error);
       return;
     }
     if (_pendingClose) {
@@ -433,7 +433,7 @@ class UserProfilePageState extends ConsumerState<UserProfilePage> {
       _userProfile!.email = _emailController.text;
       if (_pendingImageChange != null) {
         AuthUser user = ref.read(authServiceProvider).currentUser()!;
-        _uploader.currentState!.profileImageUpload(_pendingImageChange!, user);
+        await _uploader.currentState!.profileImageUpload(_pendingImageChange!, user);
         return;
       } else {
         // just save the profile
@@ -678,7 +678,7 @@ class UserProfilePageState extends ConsumerState<UserProfilePage> {
     );
     if (result == 2) {
       _pendingClose = pendingClose;
-      _saveForm();
+      await _saveForm();
       return false;
     }
     if (result == 1) {

--- a/lib/components/camera/camera_capture_component.dart
+++ b/lib/components/camera/camera_capture_component.dart
@@ -91,7 +91,7 @@ class CameraCaptureScreenState extends State<CameraCapture>
         _initialized = true;
       });
       if (!kIsWeb && widget.captureMode != CaptureMode.preview) {
-        _controller!.startImageStream((image) {
+        await _controller!.startImageStream((image) {
           _savedImage = image;
         });
       }
@@ -246,7 +246,7 @@ class CameraCaptureScreenState extends State<CameraCapture>
       child: InkWell(
         onTap: () async {
           await HapticFeedback.lightImpact();
-          _onCameraSwitch();
+          await _onCameraSwitch();
         },
         child: Container(
           width: 40,
@@ -385,7 +385,7 @@ class CameraCaptureScreenState extends State<CameraCapture>
       setState(() {});
       _initialized = true;
       if (!kIsWeb && widget.captureMode != CaptureMode.preview) {
-        _controller!.startImageStream((image) {
+        await _controller!.startImageStream((image) {
           _savedImage = image;
         });
       }

--- a/lib/components/widgets/bottom_tray_help_dialog.dart
+++ b/lib/components/widgets/bottom_tray_help_dialog.dart
@@ -6,7 +6,7 @@ import 'package:totem/components/widgets/bottom_tray_container.dart';
 import 'package:totem/theme/index.dart';
 
 class BottomTrayHelpDialog extends StatelessWidget {
-  static showTrayHelp(BuildContext context,
+  static void showTrayHelp(BuildContext context,
       {required String title, required String detail}) async {
     await showModalBottomSheet(
       context: context,

--- a/lib/components/widgets/file_uploader.dart
+++ b/lib/components/widgets/file_uploader.dart
@@ -89,7 +89,7 @@ class FileUploaderState extends ConsumerState<FileUploader> {
   Future<void> _completeUpload(XFile? upload, {String url = ''}) async {
     if (url.isNotEmpty && widget.assignProfile) {
       var repo = ref.read(repositoryProvider);
-      repo.updateUserProfileImage(url);
+      await repo.updateUserProfileImage(url);
     }
     // await clearTemporaryFiles(upload);
     if (widget.onComplete != null) {

--- a/lib/dev/dev_page.dart
+++ b/lib/dev/dev_page.dart
@@ -42,7 +42,7 @@ class _DevPageState extends State<DevPage> {
     _init();
   }
 
-  _init() async {
+  void _init() async {
     final prefs = await SharedPreferences.getInstance();
     if (prefs.containsKey(stateKey)) {
       setState(() {
@@ -51,17 +51,17 @@ class _DevPageState extends State<DevPage> {
     }
   }
 
-  changeWidget(String widget) async {
+  void changeWidget(String widget) async {
     final prefs = await SharedPreferences.getInstance();
-    prefs.setString(stateKey, widget);
+    await prefs.setString(stateKey, widget);
     setState(() {
       displayWidget = widget;
     });
   }
 
-  reset() async {
+  void reset() async {
     final prefs = await SharedPreferences.getInstance();
-    prefs.remove(stateKey);
+    await prefs.remove(stateKey);
     setState(() {
       displayWidget = null;
     });

--- a/lib/models/audio_indicator.dart
+++ b/lib/models/audio_indicator.dart
@@ -9,7 +9,7 @@ class CommunicationAudioVolumeInfo {
     required this.speaking,
   });
 
-  get local => uid == 0;
+  bool get local => uid == 0;
 }
 
 class CommunicationAudioVolumeIndication {

--- a/lib/services/agora/agora_communication_provider.dart
+++ b/lib/services/agora/agora_communication_provider.dart
@@ -574,7 +574,7 @@ class AgoraCommunicationProvider extends CommunicationProvider {
     // for android, start a foreground service to keep the process running
     // to prevent drops in connection
     if (!kIsWeb && Platform.isAndroid) {
-      SessionForeground.instance.startSessionTask();
+      await SessionForeground.instance.startSessionTask();
     }
     // notify of state to others
     notifyState();
@@ -586,7 +586,7 @@ class AgoraCommunicationProvider extends CommunicationProvider {
     // for android, stop the foreground service to keep the process running
     // to prevent drops in connection
     if (!kIsWeb && Platform.isAndroid) {
-      SessionForeground.instance.stopSessionTask();
+      await SessionForeground.instance.stopSessionTask();
     }
 
     // end the data session and update state
@@ -635,7 +635,7 @@ class AgoraCommunicationProvider extends CommunicationProvider {
   @override
   Future<void> muteAudio(bool mute) async {
     if (mute != muted) {
-      _engine?.muteLocalAudioStream(mute);
+      await _engine?.muteLocalAudioStream(mute);
       if (state != CommunicationState.active) {
         // reflect the state locally if not in a session
         muted = mute;
@@ -730,7 +730,7 @@ class AgoraCommunicationProvider extends CommunicationProvider {
         } else {
           _engine?.startPreview();
         } */
-      _engine?.enableLocalVideo(!mute);
+      await _engine?.enableLocalVideo(!mute);
       // FIXME - TEMP - Right now it seems that the
       // video publishing changes made locally are
       // not coming, so to work around this,
@@ -809,7 +809,7 @@ class AgoraCommunicationProvider extends CommunicationProvider {
     try {
       if (device != _audioInput) {
         await _engine!.enableLocalAudio(false);
-        _engine!.deviceManager.setAudioRecordingDevice(device.id);
+        await _engine!.deviceManager.setAudioRecordingDevice(device.id);
         await _engine!.enableLocalAudio(true);
         _audioInput = device;
         notifyListeners();
@@ -846,9 +846,9 @@ class AgoraCommunicationProvider extends CommunicationProvider {
     if (_engine == null) return false;
     try {
       if (device != _camera) {
-        _engine!.stopPreview();
-        _engine!.deviceManager.setVideoDevice(device.id);
-        _engine!.startPreview();
+        await _engine!.stopPreview();
+        await _engine!.deviceManager.setVideoDevice(device.id);
+        await _engine!.startPreview();
         _camera = device;
         notifyListeners();
       }

--- a/lib/services/applinks/app_links_device.dart
+++ b/lib/services/applinks/app_links_device.dart
@@ -29,7 +29,7 @@ class AppLinks {
     final PendingDynamicLinkData? initialLink =
         await FirebaseDynamicLinks.instance.getInitialLink();
     if (initialLink != null) {
-      _handleDynamicLink(initialLink.link);
+      await _handleDynamicLink(initialLink.link);
     }
     _subscription = dynamicLinks.onLink.listen((dynamicLinkData) {
       _handleDynamicLink(dynamicLinkData.link);

--- a/lib/services/audio_level/audio_level_impl.dart
+++ b/lib/services/audio_level/audio_level_impl.dart
@@ -24,7 +24,7 @@ abstract class AudioLevelImpl {
 
   void stop();
 
-  emitData(double level) {
+  void emitData(double level) {
     double adjustedLevel = adjustLevel(level);
     if (adjustedLevel != lastLevel) {
       lastLevel = adjustedLevel;

--- a/lib/services/audio_level/audio_level_mobile.dart
+++ b/lib/services/audio_level/audio_level_mobile.dart
@@ -19,7 +19,7 @@ class AudioLevel extends AudioLevelImpl {
 
   @override
   void stop() async {
-    _noiseSubscription?.cancel();
+    await _noiseSubscription?.cancel();
     _noiseSubscription = null;
     _noiseMeter = null;
   }

--- a/lib/services/audio_level/audio_level_web.dart
+++ b/lib/services/audio_level/audio_level_web.dart
@@ -2,10 +2,10 @@ import 'package:js/js.dart';
 import 'audio_level_impl.dart';
 
 @JS('AudioLevels.getAudioLevel')
-external _getAudioLevel(Function(double) callback);
+external void _getAudioLevel(Function(double) callback);
 
 @JS('AudioLevels.stopAudioStream')
-external stopAudioStream();
+external void stopAudioStream();
 
 class AudioLevel extends AudioLevelImpl {
   @override

--- a/lib/services/firebase_providers/firebase_session_provider.dart
+++ b/lib/services/firebase_providers/firebase_session_provider.dart
@@ -53,7 +53,7 @@ class FirebaseSessionProvider extends SessionProvider {
       Map<String, dynamic> circleData = {"activeSession": sessionRef};
       batch.update(ref, circleData);
       await batch.commit();
-      createActiveSession(circle: session.circle, uid: uid);
+      await createActiveSession(circle: session.circle, uid: uid);
       return _activeSession!;
     }
     throw ServiceException(
@@ -390,7 +390,7 @@ class FirebaseSessionProvider extends SessionProvider {
           _activeSession!.updateFromData(sessionData);
       if (requestedUpdate != null) {
         // have to update the user
-        updateActiveSession(requestedUpdate);
+        await updateActiveSession(requestedUpdate);
       }
       notifyListeners();
     }
@@ -427,7 +427,7 @@ class FirebaseSessionProvider extends SessionProvider {
         .doc(session.circle.id);
     DocumentReference circleRef =
         FirebaseFirestore.instance.doc(session.circle.ref);
-    FirebaseFirestore.instance.runTransaction((transaction) async {
+    await FirebaseFirestore.instance.runTransaction((transaction) async {
       DocumentSnapshot circleDataSnapshot = await transaction.get(circleRef);
       DocumentSnapshot activeDataSnapshot = await transaction.get(ref);
       if (circleDataSnapshot.exists && activeDataSnapshot.exists) {

--- a/lib/services/utils/device_type_web.dart
+++ b/lib/services/utils/device_type_web.dart
@@ -15,7 +15,7 @@ class DeviceType {
     return _isMobile!;
   }
 
-  static _assertUserAgent() {
+  static void _assertUserAgent() {
     _userAgent ??= html.window.navigator.userAgent.toString().toLowerCase();
   }
 


### PR DESCRIPTION
@schalky, I was thinking about the bug you found having to do with missing `await` and it turns out there is a lint for it: https://dart-lang.github.io/linter/lints/unawaited_futures.html. This way the code has to explicitly mark futures as `unawaited` (in dart:async) if that's actually what we want.

Do any of these changes seem problematic to you? I also added the required return type one, but that only seemed to find code that didn't have `void`.